### PR TITLE
Fixing ImportError: cannot import name NERTagger #3

### DIFF
--- a/nltkserver/stanfordner.py
+++ b/nltkserver/stanfordner.py
@@ -1,10 +1,10 @@
-from nltk.tag.stanford import NERTagger
+from nltk.tag.stanford import StanfordNERTagger
 from helpers import ret_success
 from helpers import ret_failure
 
 def tagger(data):
 	try:
-		st=NERTagger('./nltk-data/StanfordNER/english.all.3class.distsim.crf.ser.gz','./nltk-data/StanfordNER/stanford-ner.jar')
+		st=StanfordNERTagger('./nltk-data/StanfordNER/english.all.3class.distsim.crf.ser.gz','./nltk-data/StanfordNER/stanford-ner.jar')
 	except:
 		return ret_failure(705)
 	#try:


### PR DESCRIPTION
Updating NERTagger to StanfordNERTagger in order to fiz `Fixing ImportError: cannot import name NERTagger` error 